### PR TITLE
Use inspect to get tasks from celery workers

### DIFF
--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -65,10 +65,16 @@ def dump_procs(procs):
     JSON format.
     """
     data = []
+    cache = {}
     for name, proc in procs.items():
+        try:
+            quantity = proc.quantity(cache=cache)
+        except TypeError:
+            quantity = proc.quantity()
+
         data.append({
             'name': name,
-            'quantity': proc.quantity() or 'null',
+            'quantity': quantity or 'null',
         })
     return json.dumps(data, cls=TimeAwareJSONEncoder, ensure_ascii=False)
 
@@ -123,11 +129,18 @@ class Proc(object):
         return ("<Proc %s: '%s.%s'>" %
                 (self.name, cls.__module__, cls.__name__))
 
-    def quantity(self, *args, **kwargs):
+    def quantity(self, **kwargs):
         """
         Returns the aggregated number of tasks of the proc queues.
 
         Needs to be implemented in a subclass.
+
+        ``kwargs`` must be captured even when not used, to allow for
+        future extensions.
+
+        The only kwarg currently implemented is ``cache``, which is
+        a dictionary made available for cross-proc caching. It is
+        empty when the first proc is processed.
         """
         raise NotImplementedError
 

--- a/hirefire/procs/celery.py
+++ b/hirefire/procs/celery.py
@@ -1,8 +1,60 @@
 from __future__ import absolute_import
+from itertools import chain
 
 from celery.app import app_or_default
 
+from ..utils import KeyDefaultDict
 from . import Proc
+
+
+class CeleryInspector(KeyDefaultDict):
+    """
+    A defaultdict that manages the celery inspector cache.
+    """
+
+    def __init__(self, app):
+        super(CeleryInspector, self).__init__(self.get_status_task_counts)
+        self.app = app
+        self.route_queues = None
+
+    def get_route_queues(self):
+        """Find the queue to each active routing pair.
+
+        Cache to avoid additional calls to inspect().
+
+        Returns a mapping from (exchange, routing_key) to queue_name.
+        """
+        if self.route_queues is not None:
+            return self.route_queues
+
+        worker_queues = self.app.control.inspect().active_queues()
+        active_queues = chain.from_iterable(worker_queues.values())
+
+        self.route_queues = {
+            (queue['exchange']['name'], queue['routing_key']): queue['name']
+            for queue in active_queues
+        }
+        return self.route_queues
+
+    def get_status_task_counts(self, status):
+        """Get the tasks on all queues for the given status.
+
+        This is called lazily to avoid running long methods when not needed.
+        """
+        if status not in ['active', 'reserved', 'scheduled']:
+            raise KeyError('Invalid task status: {}'.format(status))
+
+        route_queues = self.get_route_queues()
+        inspected = getattr(self.app.control.inspect(), status)()
+
+        counts = KeyDefaultDict(lambda: 0)
+        for task in chain.from_iterable(inspected.values()):
+            exchange = task['delivery_info']['exchange']
+            routing_key = task['delivery_info']['routing_key']
+            queue = route_queues[exchange, routing_key]
+            counts[queue] += 1
+
+        return counts
 
 
 class CeleryProc(Proc):
@@ -52,6 +104,10 @@ class CeleryProc(Proc):
     #: The Celery app to check for the queues (optional).
     app = None
 
+    #: The Celery task status to check for on workers (optional).
+    #: Valid options are 'active', 'reserved', and 'scheduled'.
+    inspect_statuses = []  # Empty to default to previous results
+
     def __init__(self, app=None, *args, **kwargs):
         super(CeleryProc, self).__init__(*args, **kwargs)
         if app is not None:
@@ -60,7 +116,7 @@ class CeleryProc(Proc):
         self.connection = self.app.connection()
         self.channel = self.connection.channel()
 
-    def quantity(self, **kwargs):
+    def quantity(self, cache=None, **kwargs):
         """
         Returns the aggregated number of tasks of the proc queues.
         """
@@ -81,4 +137,17 @@ class CeleryProc(Proc):
                 pass
             else:
                 count += queue.message_count
+
+        if cache is not None and self.inspect_statuses:
+            count += self.inspect_count(cache)
+
         return count
+
+    def inspect_count(self, cache):
+        """Use Celery's inspect() methods to see tasks on workers."""
+        cache.setdefault('celery_inspect', KeyDefaultDict(CeleryInspector))
+        return sum(
+            cache['celery_inspect'][self.app][status][queue]
+            for status in self.inspect_statuses
+            for queue in self.queues
+        )

--- a/hirefire/procs/celery.py
+++ b/hirefire/procs/celery.py
@@ -80,8 +80,12 @@ class CeleryInspector(KeyDefaultDict):
         if status not in ['active', 'reserved', 'scheduled']:
             raise KeyError('Invalid task status: {}'.format(status))
 
-        queues = map(self.get_queue_fn(status),
-                     chain.from_iterable(self.inspect[status].values()))
+        tasks = chain.from_iterable(self.inspect[status].values())
+        queues = map(self.get_queue_fn(status), tasks)
+
+        if status == 'scheduled':
+            queues = set(queues)  # Only count each queue once
+
         return Counter(queues)
 
 

--- a/hirefire/procs/celery.py
+++ b/hirefire/procs/celery.py
@@ -60,7 +60,7 @@ class CeleryProc(Proc):
         self.connection = self.app.connection()
         self.channel = self.connection.channel()
 
-    def quantity(self):
+    def quantity(self, **kwargs):
         """
         Returns the aggregated number of tasks of the proc queues.
         """

--- a/hirefire/procs/celery.py
+++ b/hirefire/procs/celery.py
@@ -28,7 +28,7 @@ class CeleryInspector(KeyDefaultDict):
         if self.route_queues is not None:
             return self.route_queues
 
-        worker_queues = self.app.control.inspect().active_queues()
+        worker_queues = self.app.control.inspect().active_queues() or {}
         active_queues = chain.from_iterable(worker_queues.values())
 
         self.route_queues = {

--- a/hirefire/procs/hotqueue.py
+++ b/hirefire/procs/hotqueue.py
@@ -56,7 +56,7 @@ class HotQueueProc(ClientProc):
             return queue
         return HotQueue(queue, **self.connection_params)
 
-    def quantity(self):
+    def quantity(self. **kwargs):
         """
         Returns the aggregated number of tasks of the proc queues.
         """

--- a/hirefire/procs/huey.py
+++ b/hirefire/procs/huey.py
@@ -74,7 +74,7 @@ class HueyRedisProc(ClientProc):
             return queue
         return self.client_cls(queue, **self.connection_params)
 
-    def quantity(self):
+    def quantity(self, **kwargs):
         """
         Returns the aggregated number of tasks of the proc queues.
         """

--- a/hirefire/procs/pq.py
+++ b/hirefire/procs/pq.py
@@ -42,7 +42,7 @@ class PQProc(ClientProc):
             return queue
         return Job.objects.filter(status=Job.QUEUED, queue__name=queue)
 
-    def quantity(self):
+    def quantity(self, **kwargs):
         """
         Returns the aggregated number of job of the proc queues.
         """

--- a/hirefire/procs/queues.py
+++ b/hirefire/procs/queues.py
@@ -41,7 +41,7 @@ class QueuesProc(ClientProc):
             return queue
         return _queues.Queue(queue)
 
-    def quantity(self):
+    def quantity(self, **kwargs):
         """
         Returns the aggregated number of tasks of the proc queues.
         """

--- a/hirefire/procs/rq.py
+++ b/hirefire/procs/rq.py
@@ -50,7 +50,7 @@ class RQProc(ClientProc):
             return queue
         return Queue(queue, connection=self.connection)
 
-    def quantity(self):
+    def quantity(self, **kwargs):
         """
         Returns the aggregated number of tasks of the proc queues.
         """

--- a/hirefire/utils.py
+++ b/hirefire/utils.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import decimal
 import json
@@ -96,3 +97,22 @@ class TimeAwareJSONEncoder(json.JSONEncoder):
             return str(o)
         else:
             return super(TimeAwareJSONEncoder, self).default(o)
+
+
+class KeyDefaultDict(collections.defaultdict):
+    """
+    A defaultdict where the default_factory can get the key as an arg.
+    """
+
+    def __missing__(self, key):
+        """Attempt calling the factory with the key.
+
+        If the normal methods don't work, try calling the
+        ``default_factory`` with the key as an arg.
+        """
+        try:
+            return super(KeyDefaultDict, self).__missing__(key)
+        except TypeError:
+            value = self.default_factory(key)
+            self[key] = value
+            return value


### PR DESCRIPTION
Fixes #8 

In-progress celery tasks haven't been considered. This adds getting those active jobs.

Unfortunately, the methods to run to get those jobs are quite expensive. Fortunately, they can be run once per request and get all the needed data. Add a request-wide cache dictionary for use in optimizations like this. In this case, having a cache allows us to keep the Celery complexity in the celery-specific proc, and keep the request-wide code clean, agnostic, and reasonably simple.