### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,6 @@
 .. _Heroku: http://www.heroku.com/
 .. _Celery: http://celeryproject.com/
 .. _HotQueue: http://richardhenry.github.com/hotqueue/
-.. _Huey: http://huey.readthedocs.org/
+.. _Huey: https://huey.readthedocs.io/
 .. _Queues: http://queues.googlecode.com/
 .. _RQ: http://python-rq.org/

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ queuing system.
 .. _Heroku: http://www.heroku.com/
 .. _Celery: http://celeryproject.com/
 .. _HotQueue: http://richardhenry.github.com/hotqueue/
-.. _Huey: http://huey.readthedocs.org/
+.. _Huey: https://huey.readthedocs.io/
 .. _Queues: http://queues.googlecode.com/
 .. _RQ: http://python-rq.org/
 .. _`contribute other backends`: https://github.com/jezdez/hirefire/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,7 +248,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('http://docs.python.org/', None),
-    'django': ('http://django.readthedocs.org/en/latest/', None),
+    'django': ('https://django.readthedocs.io/en/latest/', None),
     'celery': ('http://docs.celeryproject.org/en/latest/', None),
-    'huey': ('http://huey.readthedocs.org/en/latest/', None),
+    'huey': ('https://huey.readthedocs.io/en/latest/', None),
 }

--- a/hirefire/procs/huey.py
+++ b/hirefire/procs/huey.py
@@ -8,7 +8,7 @@ from . import ClientProc
 class HueyRedisProc(ClientProc):
     """
     A proc class for the redis backend of the
-    `Huey <http://huey.readthedocs.org/>`_ library.
+    `Huey <https://huey.readthedocs.io/>`_ library.
 
     :param name: the name of the proc (required)
     :param queues: list of queue names to check (required)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def find_version(*parts):
 setup(
     name='HireFire',
     version=find_version('hirefire', '__init__.py'),
-    url='http://hirefire.readthedocs.org/',
+    url='https://hirefire.readthedocs.io/',
     license='BSD',
     description='A Python lib to integrate with the HireFire service -- '
                 'The Heroku Proccess Manager',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.