### PR TITLE
Add support for Django 1.10 style middlware via `MiddlewareMixin`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,9 +113,9 @@ Django
 Setting up HireFire support for Django is easy:
 
 #. Add ``'hirefire.contrib.django.middleware.HireFireMiddleware'`` to your
-   ``MIDDLEWARE_CLASSES`` setting::
-
-     MIDDLEWARE_CLASSES = [
+   ``MIDDLEWARE`` setting::
+     # Use ``MIDDLEWARE_CLASSES`` prior to Django 1.10
+     MIDDLEWARE = [
          'hirefire.contrib.django.middleware.HireFireMiddleware',
          # ...
      ]

--- a/hirefire/contrib/django/middleware.py
+++ b/hirefire/contrib/django/middleware.py
@@ -6,6 +6,15 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 
+try:
+    # Django >= 1.10
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
+
+
 from hirefire.procs import load_procs, dump_procs, HIREFIRE_FOUND
 
 
@@ -22,7 +31,7 @@ if not PROCS:
                                'in the HIREFIRE_PROCS setting.')
 
 
-class HireFireMiddleware(object):
+class HireFireMiddleware(MiddlewareMixin):
     """
     The Django middleware that is hardwired to the URL paths
     HireFire requires. Implements the test response and the


### PR DESCRIPTION
  - See https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
  - Catch import error for Django versions < 1.10
  - Inspired by https://github.com/zestedesavoir/django-cors-middleware/pull/25/files
  - Update docs to use `MIDDLEWARE` instead of `MIDDLEWARE_CLASSES` for Django >= 1.10