### PR TITLE
fix server error with empty exchange info in task

### DIFF
--- a/hirefire/procs/celery.py
+++ b/hirefire/procs/celery.py
@@ -63,8 +63,12 @@ class CeleryInspector(KeyDefaultDict):
         route_queues = self.get_route_queues()
 
         def identify_queue(delivery_info):
-            exchange = delivery_info['exchange']
             routing_key = delivery_info['routing_key']
+
+            exchange = delivery_info['exchange']
+            if not exchange:
+                exchange = routing_key
+
             return route_queues[exchange, routing_key]
 
         def get_queue(task):


### PR DESCRIPTION
we have a quite simple rabbitmq setup (4 queues, and queue/exchange/routing-key are named the same). 

we are seeing errors like this

```
TypeError: get_status_task_counts() missing 1 required positional argument: 'status'
  File "hirefire/utils.py", line 114, in __missing__
    return super(KeyDefaultDict, self).__missing__(key)
KeyError: ('', 'lowprio')
  File "django/core/handlers/base.py", line 123, in get_response
    response = middleware_method(request)
  File "newrelic/hooks/framework_django.py", line 232, in wrapper
    return wrapped(*args, **kwargs)
  File "hirefire/contrib/django/middleware.py", line 56, in process_request
    return self.info(request)
  File "hirefire/contrib/django/middleware.py", line 46, in info
    payload = dump_procs(self.loaded_procs)
  File "hirefire/procs/__init__.py", line 71, in dump_procs
    quantity = proc.quantity(cache=cache)
  File "hirefire/procs/celery.py", line 210, in quantity
    count += self.inspect_count(cache)
  File "hirefire/procs/celery.py", line 219, in inspect_count
    for status in self.inspect_statuses
  File "hirefire/procs/celery.py", line 220, in <genexpr>
    for queue in self.queues
  File "hirefire/utils.py", line 116, in __missing__
    value = self.default_factory(key)
  File "hirefire/procs/celery.py", line 88, in get_status_task_counts
    queues = set(queues)  # Only count each queue once
  File "hirefire/procs/celery.py", line 72, in get_queue
    return identify_queue(task['request']['delivery_info'])
  File "hirefire/procs/celery.py", line 68, in identify_queue
    return route_queues[exchange, routing_key]
```

With celery 3, they were random. With celery 4 we see them all the time. 

This code fixes it for us. 