### PR TITLE
Dump refactor

### DIFF
--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -74,7 +74,7 @@ def dump_procs(procs):
 
         data.append({
             'name': name,
-            'quantity': quantity or 'null',
+            'quantity': quantity or 0,
         })
     return json.dumps(data, cls=TimeAwareJSONEncoder, ensure_ascii=False)
 

--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -59,10 +59,11 @@ def load_procs(*procs):
     return loaded_procs
 
 
-def dump_procs(procs):
+def native_dump_procs(procs):
     """
-    Given a list of loaded procs dumps the data for them in
-    JSON format.
+    Given a list of loaded procs, dump the data for them into
+    a list of dictionaries in the form expected by HireFire,
+    ready to be encoded into JSON.
     """
     data = []
     cache = {}
@@ -76,6 +77,15 @@ def dump_procs(procs):
             'name': name,
             'quantity': quantity or 0,
         })
+    return data
+
+
+def dump_procs(procs):
+    """
+    Given a list of loaded procs dumps the data for them in
+    JSON format.
+    """
+    data = native_dump_procs(procs)
     return json.dumps(data, cls=TimeAwareJSONEncoder, ensure_ascii=False)
 
 


### PR DESCRIPTION
First, make the fallback quantity 0, which is what is advised by HireFire. That the string `'null'` even works is a fluke of implementation, and 0 is the right default to have.

Then, split up the JSON encoding from the payload generation. This makes it possible to interface with with a defined function to get the data that HireFire collects, without having to un-encode it to use it in Python.